### PR TITLE
fix: Ensure client-side code only runs in the browser

### DIFF
--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -1,12 +1,11 @@
 "use client";
+import { useEffect, useState } from "react";
+import { CaretDown, CaretUp } from "@phosphor-icons/react";
 import DeliveryAddressForm from "../components/checkout/DeliveryAddressForm";
 import ContactForm from "../components/checkout/ContactForm";
 import { lato } from "../fonts/fonts";
 import { useStateStorage } from "../../utils/stateStorage";
 import { sanityImageBuilder } from "../../utils/sanityImageBuilder";
-//---Framework---//
-import { useEffect, useState } from "react";
-import { CaretDown, CaretUp } from "@phosphor-icons/react";
 import PaymentWithSquare from "../components/checkout/PaymentWithSquare";
 
 const CheckoutPage = () => {
@@ -23,10 +22,12 @@ const CheckoutPage = () => {
 	};
 
 	useEffect(() => {
-		window.addEventListener("scroll", handleScroll);
-		return () => {
-			window.removeEventListener("scroll", handleScroll);
-		};
+		if (typeof window !== "undefined") {
+			window.addEventListener("scroll", handleScroll);
+			return () => {
+				window.removeEventListener("scroll", handleScroll);
+			};
+		}
 	}, []);
 
 	const toggleOrderSummary = () => {
@@ -62,7 +63,8 @@ const CheckoutPage = () => {
 								.toFixed(2)}
 						</span>
 					</div>
-					{(isOrderSummaryOpen || window.innerWidth >= 640) && (
+					{(isOrderSummaryOpen ||
+						(typeof window !== "undefined" && window.innerWidth >= 640)) && (
 						<div className="flex flex-col gap-4">
 							{state.cart.cartItems.map((item, index) => (
 								<div

--- a/app/components/checkout/PaymentWithSquare.jsx
+++ b/app/components/checkout/PaymentWithSquare.jsx
@@ -1,19 +1,21 @@
 "use client";
-import { useState } from "react";
-import { submitPayment } from "../../actions/squarePaymentAction";
-//---Packages--///
+import { useState, useEffect } from "react";
 import {
 	CreditCard,
 	PaymentForm,
 	GooglePay,
 } from "react-square-web-payments-sdk";
-import {
-	CreditCard as CreditCardIcon,
-	GoogleChromeLogo,
-} from "@phosphor-icons/react";
 
 const PaymentWithSquare = () => {
 	const [selectedPaymentMethod, setSelectedPaymentMethod] = useState(null);
+	const [isClient, setIsClient] = useState(false);
+
+	useEffect(() => {
+		if (typeof window !== "undefined") {
+			setIsClient(true);
+		}
+	}, []);
+
 	const appId = process.env.NEXT_PUBLIC_SQUARE_APP_ID;
 	const locationId = process.env.NEXT_PUBLIC_SQUARE_LOCATION_ID;
 
@@ -32,6 +34,10 @@ const PaymentWithSquare = () => {
 			},
 		};
 	};
+
+	if (!isClient) {
+		return null; // or a loading spinner
+	}
 
 	return (
 		<div className="flex flex-col items-center w-full px-4">


### PR DESCRIPTION
- Added client-side checks for `window` object usage in `CheckoutPage` and `PaymentWithSquare` components.
- Moved `useEffect` hooks to conditionally add/remove event listeners based on client-side execution.
- Updated conditional rendering to prevent server-side rendering errors.